### PR TITLE
Change data structure HashMap to LinkedHashMap to fix flaky test

### DIFF
--- a/pushy/src/main/java/com/eatthepath/pushy/apns/auth/AuthenticationToken.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/auth/AuthenticationToken.java
@@ -37,7 +37,7 @@ import java.security.Signature;
 import java.security.SignatureException;
 import java.text.ParseException;
 import java.time.Instant;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -86,7 +86,7 @@ public class AuthenticationToken {
         }
 
         Map<String, Object> toMap() {
-            final Map<String, Object> headerMap = new HashMap<>(3, 1);
+            final Map<String, Object> headerMap = new LinkedHashMap<>(3, 1);
             headerMap.put("alg", "ES256");
             headerMap.put("typ", "JWT");
             headerMap.put("kid", this.keyId);
@@ -129,7 +129,7 @@ public class AuthenticationToken {
         }
 
         Map<String, Object> toMap() {
-            final Map<String, Object> headerMap = new HashMap<>(2, 1);
+            final Map<String, Object> headerMap = new LinkedHashMap<>(2, 1);
             headerMap.put("iss", this.issuer);
             headerMap.put("iat", this.issuedAt.getEpochSecond());
 


### PR DESCRIPTION
Summary:

This the fix for the flaky test case
```
com.eatthepath.pushy.apns.server.TokenAuthenticationValidatingPushNotificationHandlerTest.testHandleNotificationWithWithExpiredAuthenticationToken
```
This test is detected as flaky by the NonDex tool developed by researchers at UIUC. (https://github.com/TestingResearchIllinois/NonDex)

Flaky tests are tests in software development that produce inconsistent or unreliable results, which can lead to false non-deterministic outcomes of the test case, fixing them is important to both reliable testing and fixing vulnerabilities in the code.

The outcomes of the ```TokenAuthenticationValidatingPushNotificationHandler``` are sometimes ```INVALID_PROVIDER_TOKEN``` instead of ```EXPIRED_PROVIDER_TOKEN``` which is why the ```assert``` fails
This is because the ```verifySignature``` method fails before reaching the line of code which detects an ```EXPIRED_PROVIDER_TOKEN```

The ```verifySignature``` method in ```AuthenticationToken``` class converts ```headerJson``` and ```clainsJson``` to ```hashmap``` and then to string in order for token authentication. The elements in the ```hashmap``` are not guaranteed to be in the same order always which introduces a vulnerability in the code, however elements in a ```LinkedHashmap``` are guaranteed to be stored in a particular order. The authentication may fail and result in ```INVALID_PROVIDER_TOKEN``` even if it is correct.

Fix: Use ```LinkedHashMap``` instead ```HashMap```

Tests Plan:

 ```
mvn -pl pushy edu.illinois:nondex-maven-plugin:2.1.1:nondex Dtest=com.eatthepath.pushy.apns.server.TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithWithExpiredAuthenticationToken
```
